### PR TITLE
don't treat CAT as success anymore

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1817,13 +1817,18 @@ static bool ExecuteWitnessScript(const Span<const valtype>& stack_span, const CS
             }
             // New opcodes will be listed here. May use a different sigversion to modify existing opcodes.
             if (IsOpSuccess(opcode)) {
-                if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS) {
+                if (flags & SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS && opcode != OP_CAT) {
                     return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_SUCCESS);
                 }
                 if (flags & SCRIPT_VERIFY_DISCOURAGE_TAPSCRIPT_OP_CAT) {
                     return set_error(serror, SCRIPT_ERR_DISCOURAGE_OP_CAT);
                 }
-                return set_success(serror);
+                // OP_CAT used to be an OP_SUCCESS. Once it has been re-activated, it should no longer be treated
+                // that way. NOTE: This check should depend on whatever activation logic is used. Right now it will
+                // never treat OP_CAT as an OP_SUCCESS.
+                if (opcode != OP_CAT) {
+                    return set_success(serror);
+                }
             }
         }
 


### PR DESCRIPTION
CAT is still being treated as an OP_SUCCESS, so invalid scripts will still pass validation. This PR carves out CAT in the success check. This is probably **not** the right thing for the final state, but the final state will probably involve a check to see if CAT has been activated, so right now it just unconditionally assumes CAT is active. 
