### PR TITLE
Removes check on witness stack position for control block flag

### DIFF
--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -949,7 +949,7 @@ BOOST_AUTO_TEST_CASE(script_json_test)
                 if (element.find(scriptFlag) == 0) {
                     CScript script = ParseScript(element.substr(scriptFlag.size()));
                     witness.stack.push_back(ToByteVector(script));
-                } else if (test[pos].size() >= 3 && i == test[pos].size()-2 && strcmp(element.c_str(), "#CONTROLBLOCK#") == 0) {
+                } else if (strcmp(element.c_str(), "#CONTROLBLOCK#") == 0) {
                     // Taproot script control block - second from the last element in witness stack
                     // If #CONTROLBLOCK# we auto-generate the control block
                     taprootBuilder.Add(/*depth=*/0, witness.stack.back(), TAPROOT_LEAF_TAPSCRIPT, /*track=*/true);


### PR DESCRIPTION
This PR removes check in script tests that the control block is in the right position and relies on control block flag. 

See discussion here: https://github.com/bitcoin-inquisition/bitcoin/pull/39/files?diff=split&w=0#r1549257393


